### PR TITLE
Fixes #8 - Checking self

### DIFF
--- a/cmp/type_builder.py
+++ b/cmp/type_builder.py
@@ -3,6 +3,9 @@ from cmp.ast import ProgramNode, ClassDeclarationNode, AttrDeclarationNode, Func
 from cmp.semantic import SemanticError, ErrorType
 
 
+SELF_IS_READONLY = 'Variable "self" is read-only.'
+
+
 class TypeBuilder:
     def __init__(self, context, errors=[]):
         self.context = context
@@ -37,6 +40,11 @@ class TypeBuilder:
         param_types = []
         for param in node.params:
             n, t = param
+
+            # Checking param name can't be self
+            if n == "self":
+                self.errors.append(SELF_IS_READONLY)
+
             param_names.append(n)
             try:
                 t = self.context.get_type(t)
@@ -67,6 +75,10 @@ class TypeBuilder:
         except SemanticError as ex:
             self.errors.append(ex.text)
             attr_type = ErrorType()
+
+        #Checking attribute can't be named self
+        if node.id == "self":
+            self.errors.append(SELF_IS_READONLY)
         
         # Checking attribute name. No other attribute can have the same name
         flag = False

--- a/cmp/type_builder.py
+++ b/cmp/type_builder.py
@@ -45,7 +45,12 @@ class TypeBuilder:
             if n == "self":
                 self.errors.append(SELF_IS_READONLY)
 
-            param_names.append(n)
+            while True:
+                if n in param_names:
+                    n = f'1{n}'
+                else:
+                    param_names.append(n)
+                    break
             try:
                 t = self.context.get_type(t)
             except SemanticError as ex:


### PR DESCRIPTION
Fixes #8 - now "self" in Function Declarion and in the Atribute Declaration report the error and get a new name to not interfere with the rest of checking