### PR TITLE
Fixes #9 - Add Auto Type and Type Inferencer

### DIFF
--- a/cmp/ast.py
+++ b/cmp/ast.py
@@ -19,6 +19,7 @@ class ClassDeclarationNode(DeclarationNode):
 class FuncDeclarationNode(DeclarationNode):
     def __init__(self, idx, params, return_type, body):
         self.id = idx
+        # param = (name, type)
         self.params = params
         self.type = return_type
         self.body = body

--- a/cmp/semantic.py
+++ b/cmp/semantic.py
@@ -145,21 +145,21 @@ class ErrorType(Type):
 
 class ObjectType(Type):
     def __init__(self):
-        Type.__init__(self, 'object')
+        Type.__init__(self, 'Object')
 
     def __eq__(self, other):
         return other.name == self.name or isinstance(other, ObjectType)    
 
 class IOType(Type):
     def __init__(self):
-        Type.__init__(self, 'io')
+        Type.__init__(self, 'IO')
 
     def __eq__(self, other):
         return other.name == self.name or isinstance(other, IOType)
 
 class StringType(Type):
     def __init__(self):
-        Type.__init__(self, 'string')
+        Type.__init__(self, 'String')
 
     def __eq__(self, other):
         return other.name == self.name or isinstance(other, StringType)
@@ -169,7 +169,7 @@ class StringType(Type):
 
 class BoolType(Type):
     def __init__(self):
-        Type.__init__(self, 'bool')
+        Type.__init__(self, 'Bool')
 
     def __eq__(self, other):
         return other.name == self.name or isinstance(other, BoolType)
@@ -179,7 +179,7 @@ class BoolType(Type):
 
 class IntType(Type):
     def __init__(self):
-        Type.__init__(self, 'int')
+        Type.__init__(self, 'Int')
 
     def __eq__(self, other):
         return other.name == self.name or isinstance(other, IntType)

--- a/cmp/semantic.py
+++ b/cmp/semantic.py
@@ -184,6 +184,16 @@ class IntType(Type):
 class SelfType(Type):
     def __init__(self):
         Type.__init__(self, 'SELF_TYPE')
+    
+    def can_be_inherited(self):
+        return False
+
+class AutoType(Type):
+    def __init__(self):
+        Type.__init__(self, 'AUTO_TYPE')
+
+    def can_be_inherited(self):
+        return False
 
 
 

--- a/cmp/semantic.py
+++ b/cmp/semantic.py
@@ -206,8 +206,9 @@ class IntType(Type):
         return False
 
 class SelfType(Type):
-    def __init__(self):
+    def __init__(self, fixed=None):
         Type.__init__(self, 'SELF_TYPE')
+        self.fixed_type = fixed
     
     def can_be_inherited(self):
         return False

--- a/cmp/semantic.py
+++ b/cmp/semantic.py
@@ -280,7 +280,7 @@ class Scope:
         try:
             return next(x for x in locals if x.name == vname)
         except StopIteration:
-            return self.parent.find_variable(vname, self.index) if self.parent is None else None
+            return self.parent.find_variable(vname, self.index) if self.parent is not None else None
 
     def is_defined(self, vname):
         return self.find_variable(vname) is not None

--- a/cmp/semantic.py
+++ b/cmp/semantic.py
@@ -323,20 +323,31 @@ class InferencerManager:
 
         return sz != len(self.conforms_to[idx])
 
-    def upd_conformed_by(self, idx, other):
-        sz = len(self.conformed_by[idx])
-        self.conformed_by[idx].update(other)
+def LCA(types):
+        # check ErrorType:
+        if any(isinstance(item, ErrorType) for item in types):
+            return ErrorType()
 
-        return sz != len(self.conformed_by[idx])
+        # check AUTO_TYPE
+        if any(isinstance(item, AutoType) for item in types):
+            return AutoType()
 
-    def auto_to_type(self, idx, typex):
-        sz = len(self.conforms_to[idx])
-        self.conforms_to[idx].add(typex.name)
+        # check SELF_TYPE:
+        if all(isinstance(item, SelfType) for item in types):
+            return types[0]
 
-        return sz != len(self.conforms_to[idx])
+        for i, item in enumerate(types):
+            if isinstance(item, SelfType):
+                types[i] = item.fixed_type
 
-    def type_to_auto(self, idx, typex):
-        sz = len(self.conformed_by[idx])
-        self.conformed_by[idx].add(typex.name)
+        current = types[0]
+        while current:
+            for item in types:
+                if not item.conforms_to(current):
+                    break
+            else:
+                return current
+            current = current.parent
 
-        return sz != len(self.conformed_by[idx])
+        # This part of the code is supposed to be unreachable
+        return None

--- a/cmp/semantic.py
+++ b/cmp/semantic.py
@@ -60,11 +60,11 @@ class Type:
             except SemanticError:
                 raise SemanticError(f'Attribute "{name}" is not defined in {self.name}.')
 
-    def define_attribute(self, name:str, typex):
+    def define_attribute(self, name:str, typex, idx=None):
         try:
             self.get_attribute(name)
         except SemanticError:
-            attribute = Attribute(name, typex)
+            attribute = Attribute(name, typex, idx)
             self.attributes.append(attribute)
             return attribute
         else:

--- a/cmp/semantic.py
+++ b/cmp/semantic.py
@@ -101,6 +101,24 @@ class Type:
             plain[method.name] = (method, self)
         return plain.values() if clean else plain
 
+    def update_attr(self, attr_name, attr_type):
+        for i, item in enumerate(self.attributes):
+            if item.name == attr_name:
+                self.attributes[i] = Attribute(attr_name, attr_type)
+                break
+    
+    def update_method_rtype(self, method_name, rtype):
+        for i, item in enumerate(self.methods):
+            if item.name == method_name:
+                self.methods[i].return_type = rtype
+                break
+
+    def update_method_param(self, method_name, param_type, param_idx):
+        for i, item in enumerate(self.methods):
+            if item.name == method_name:
+                self.methods[i].param_types[param_idx] = param_type
+                break
+
     def conforms_to(self, other):
         return other.bypass() or self == other or self.parent is not None and self.parent.conforms_to(other)
 
@@ -269,6 +287,13 @@ class Scope:
     def is_local(self, vname):
         return any(True for x in self.locals if x.name == vname)
 
+    def update_variable(self, vname, vtype, index=None):
+        locals = self.locals if index is None else itt.islice(self.locals, index)
+        for i, item in enumerate(locals):
+            if item.name == vname:
+                self.locals[i] = VariableInfo(vname, vtype, item.idx)
+                return True
+        return self.parent.update_variable(vname, vtype, self.index) if self.parent is not None else False
 
 class InferencerManager:
     def __init__(self, context):

--- a/cmp/type_builder.py
+++ b/cmp/type_builder.py
@@ -1,6 +1,6 @@
 import cmp.visitor as visitor
 from cmp.ast import ProgramNode, ClassDeclarationNode, AttrDeclarationNode, FuncDeclarationNode
-from cmp.semantic import SemanticError, ErrorType
+from cmp.semantic import SemanticError, ErrorType, InferencerManager, AutoType
 
 
 class TypeBuilder:
@@ -8,6 +8,8 @@ class TypeBuilder:
         self.context = context
         self.current_type = None
         self.errors = errors
+        self.manager = InferencerManager(context)
+
     
     @visitor.on('node')
     def visit(self, node):
@@ -35,11 +37,15 @@ class TypeBuilder:
         ## Building param-names and param-types of the method
         param_names = []
         param_types = []
+        node.index = []
         for param in node.params:
             n, t = param
             param_names.append(n)
+            node.index.append(None)
             try:
                 t = self.context.get_type(t)
+                if isinstance(t, AutoType):
+                    node.index[-1] = self.manager.assign_id()
             except SemanticError as ex:
                 self.errors.append(ex.text)
                 t = ErrorType()
@@ -52,9 +58,11 @@ class TypeBuilder:
             self.errors.append(ex.text)
             rtype = ErrorType()
         
+        node.idx = self.manager.assign_id() if isinstance(rtype, AutoType) else None
+        
         # Defining the method in the current type. There can not be another method with the same name.
         try:
-            self.current_type.define_method(node.id, param_names, param_types, rtype)
+            self.current_type.define_method(node.id, param_names, param_types, rtype, node.index, node.idx)
         except SemanticError as ex:
             self.errors.append(ex.text)
             
@@ -67,11 +75,13 @@ class TypeBuilder:
         except SemanticError as ex:
             self.errors.append(ex.text)
             attr_type = ErrorType()
+
+        node.idx = self.manager.assign_id() if isinstance(attr_type, AutoType) else None
         
         # Checking attribute name. No other attribute can have the same name
         flag = False
         try:
-            self.current_type.define_attribute(node.id, attr_type)
+            self.current_type.define_attribute(node.id, attr_type, node.idx)
             flag = True
         except SemanticError as ex:
             self.errors.append(ex.text)
@@ -79,7 +89,7 @@ class TypeBuilder:
         while not flag:
             node.id = f'1{node.id}'
             try:
-                self.current_type.define_attribute(node.id, attr_type)
+                self.current_type.define_attribute(node.id, attr_type, node.idx)
                 flag = True
             except SemanticError:
                 pass

--- a/cmp/type_builder.py
+++ b/cmp/type_builder.py
@@ -1,6 +1,6 @@
 import cmp.visitor as visitor
 from cmp.ast import ProgramNode, ClassDeclarationNode, AttrDeclarationNode, FuncDeclarationNode
-from cmp.semantic import SemanticError, ErrorType, InferencerManager, AutoType
+from cmp.semantic import SemanticError, ErrorType, InferencerManager, AutoType, SelfType
 
 
 class TypeBuilder:
@@ -8,7 +8,9 @@ class TypeBuilder:
         self.context = context
         self.current_type = None
         self.errors = errors
-        self.manager = InferencerManager(context)
+        self.manager = InferencerManager()
+        
+        self.obj_type = self.context.get_type('Object')
 
     
     @visitor.on('node')
@@ -23,14 +25,12 @@ class TypeBuilder:
 
         self.check_main_class()
     
-    
     @visitor.when(ClassDeclarationNode)
     def visit(self, node):
         self.current_type = self.context.get_type(node.id)
         for feat in node.features:
             self.visit(feat)
             
-    
     @visitor.when(FuncDeclarationNode)
     def visit(self, node):
 
@@ -44,8 +44,10 @@ class TypeBuilder:
             node.index.append(None)
             try:
                 t = self.context.get_type(t)
-                if isinstance(t, AutoType):
-                    node.index[-1] = self.manager.assign_id()
+                if isinstance(t, SelfType):
+                    t = SelfType(self.current_type)
+                elif isinstance(t, AutoType):
+                    node.index[-1] = self.manager.assign_id(self.obj_type)
             except SemanticError as ex:
                 self.errors.append(ex.text)
                 t = ErrorType()
@@ -54,11 +56,13 @@ class TypeBuilder:
         # Checking return type
         try:
             rtype = self.context.get_type(node.type)
+            if isinstance(rtype, SelfType):
+                rtype = SelfType(self.current_type)
         except SemanticError as ex:
             self.errors.append(ex.text)
             rtype = ErrorType()
         
-        node.idx = self.manager.assign_id() if isinstance(rtype, AutoType) else None
+        node.idx = self.manager.assign_id(self.obj_type) if isinstance(rtype, AutoType) else None
         
         # Defining the method in the current type. There can not be another method with the same name.
         try:
@@ -66,17 +70,18 @@ class TypeBuilder:
         except SemanticError as ex:
             self.errors.append(ex.text)
             
-    
     @visitor.when(AttrDeclarationNode)
     def visit(self, node):
         # Checking attribute type
         try:
             attr_type = self.context.get_type(node.type)
+            if isinstance(attr_type, SelfType):
+                attr_type = SelfType(self.current_type)
         except SemanticError as ex:
             self.errors.append(ex.text)
             attr_type = ErrorType()
 
-        node.idx = self.manager.assign_id() if isinstance(attr_type, AutoType) else None
+        node.idx = self.manager.assign_id(self.obj_type) if isinstance(attr_type, AutoType) else None
         
         # Checking attribute name. No other attribute can have the same name
         flag = False

--- a/cmp/type_checker.py
+++ b/cmp/type_checker.py
@@ -43,6 +43,7 @@ class TypeChecker:
     @visitor.when(ClassDeclarationNode)
     def visit(self, node, scope):
         self.current_type = self.context.get_type(node.id)
+        scope.define_variable('self', SelfType(self.current_type))
         attributes = self.current_type.all_attributes()
         for values in attributes:
             attr, _ = values
@@ -186,7 +187,7 @@ class TypeChecker:
             
             # check type is autotype and assign an id in the manager
             if isinstance(var_type, AutoType):
-                node.branch_idx[-1] = self.manager.assign_id()
+                node.branch_idx[-1] = self.manager.assign_id(self.obj_type)
 
             new_scope = nscope.create_child()
             new_scope.define_variable(idx, var_type, node.branch_idx[-1])

--- a/cmp/type_checker.py
+++ b/cmp/type_checker.py
@@ -24,10 +24,10 @@ class TypeChecker:
         self.manager = manager
 
         # built-in types
-        self.obj_type = self.context.get_type('object')
-        self.int_type = self.context.get_type('int')
-        self.bool_type = self.context.get_type('bool')
-        self.string_type = self.context.get_type('string')
+        self.obj_type = self.context.get_type('Object')
+        self.int_type = self.context.get_type('Int')
+        self.bool_type = self.context.get_type('Bool')
+        self.string_type = self.context.get_type('String')
 
     @visitor.on('node')
     def visit(self, node, scope=None):

--- a/cmp/type_collector.py
+++ b/cmp/type_collector.py
@@ -33,7 +33,6 @@ class TypeCollector(object):
         # Order class declarations according to their depth in the inheritance tree
         node.declarations = self.order_types(node)
        
-    
     @visitor.when(ClassDeclarationNode)
     def visit(self, node):
         # flag will be True if the class is succesfully added to the context
@@ -55,6 +54,7 @@ class TypeCollector(object):
             except SemanticError:
                 pass
     
+
     def define_built_in_types(self):
         objectx = ObjectType()
         iox = IOType()
@@ -65,20 +65,20 @@ class TypeCollector(object):
         autotype = AutoType()
 
         # Object Methods
-        objectx.define_method('abort', [], [], objectx)
-        objectx.define_method('type_name', [], [], stringx)
-        objectx.define_method('copy', [], [], self_type)
+        objectx.define_method('abort', [], [], objectx, [])
+        objectx.define_method('type_name', [], [], stringx, [])
+        objectx.define_method('copy', [], [], self_type, [])
 
         # IO Methods
-        iox.define_method('out_string', ['x'], [stringx], self_type)
-        iox.define_method('out_int', ['x'], [intx], self_type)
-        iox.define_method('in_string', [], [], stringx)
-        iox.define_method('in_int', [], [], intx)
+        iox.define_method('out_string', ['x'], [stringx], self_type, [None])
+        iox.define_method('out_int', ['x'], [intx], self_type, [None])
+        iox.define_method('in_string', [], [], stringx, [])
+        iox.define_method('in_int', [], [], intx, [])
 
         # String Methods
-        stringx.define_method('length', [], [], intx)
-        stringx.define_method('concat', ['s'], [stringx], stringx)
-        stringx.define_method('substr', ['i', 'l'], [intx, intx], stringx)
+        stringx.define_method('length', [], [], intx, [])
+        stringx.define_method('concat', ['s'], [stringx], stringx, [None])
+        stringx.define_method('substr', ['i', 'l'], [intx, intx], stringx, [None])
         
         # Setting Object as parent
         iox.set_parent(objectx)
@@ -105,7 +105,6 @@ class TypeCollector(object):
                     self.errors.append(ex.text)
                     item_type.set_parent(built_in_types[0])
     
-
     def check_cyclic_inheritance(self):
         flag = []
         
@@ -134,8 +133,6 @@ class TypeCollector(object):
             if idx == len(flag):
                 check_path(idx, item)
         
-
-
     def order_types(self, node):
         sorted_declarations = []
         flag = [False] * len(node.declarations)

--- a/cmp/type_collector.py
+++ b/cmp/type_collector.py
@@ -1,5 +1,5 @@
 import cmp.visitor as visitor
-from cmp.semantic import SemanticError, Type, Context, ObjectType, IOType, StringType, IntType, BoolType, SelfType
+from cmp.semantic import SemanticError, Type, Context, ObjectType, IOType, StringType, IntType, BoolType, SelfType, AutoType
 from cmp.ast import ProgramNode, ClassDeclarationNode
 
 built_in_types = []
@@ -62,6 +62,7 @@ class TypeCollector(object):
         stringx = StringType()
         boolx = BoolType()
         self_type = SelfType()
+        autotype = AutoType()
 
         # Object Methods
         objectx.define_method('abort', [], [], objectx)
@@ -85,7 +86,7 @@ class TypeCollector(object):
         intx.set_parent(objectx)
         boolx.set_parent(objectx)
 
-        built_in_types.extend([objectx, iox, stringx, intx, boolx, self_type])
+        built_in_types.extend([objectx, iox, stringx, intx, boolx, self_type, autotype])
         
     def check_parents(self):
         for item in self.parent.keys():

--- a/cmp/type_inferencer.py
+++ b/cmp/type_inferencer.py
@@ -1,0 +1,470 @@
+import cmp.visitor as visitor
+from cmp.semantic import SemanticError, ErrorType, SelfType, AutoType, LCA
+from cmp.ast import ProgramNode, ClassDeclarationNode, AttrDeclarationNode, FuncDeclarationNode
+from cmp.ast import AssignNode, CallNode, CaseNode, BlockNode, LoopNode, ConditionalNode, LetNode
+from cmp.ast import ArithmeticNode, ComparisonNode, EqualNode
+from cmp.ast import VoidNode, NotNode, NegNode
+from cmp.ast import ConstantNumNode, ConstantStringNode, ConstantBoolNode, VariableNode, InstantiateNode
+
+
+TYPE_CONFORMANCE = 'Type "%s" can not conform to type "%s"'
+AUTOTYPE_ERROR = 'Incorrect use of AUTO_TYPE'
+
+class TypeInferencer:
+    def __init__(self, context, manager, errors=[]):
+        self.context = context
+        self.errors = errors
+        self.manager = manager
+        
+        self.current_type = None
+        self.current_method = None
+        self.scope_children_id = 0
+
+        # built-in types
+        self.obj_type = self.context.get_type('Object')
+        self.int_type = self.context.get_type('Int')
+        self.bool_type = self.context.get_type('Bool')
+        self.string_type = self.context.get_type('String')
+
+    @visitor.on('node')
+    def visit(self, node, scope, types=None):
+        pass
+
+    @visitor.when(ProgramNode)
+    def visit(self, node, scope, types=None):
+        if types is None:
+            types = []
+
+        change = self.manager.count > 0
+        while change:
+            change = False
+
+            for declaration, child_scope in zip(node.declarations, scope.children):
+                self.scope_children_id = 0
+                self.visit(declaration, child_scope, types)
+
+            change = self.manager.infer_all()
+
+        self.manager.infer_object(self.obj_type)
+        for declaration, child_scope in zip(node.declarations, scope.children):
+                self.scope_children_id = 0
+                self.visit(declaration, child_scope, types)
+            
+    @visitor.when(ClassDeclarationNode)
+    def visit(self, node, scope, types):
+        self.current_type = self.context.get_type(node.id)
+            
+        for feature, child_scope in zip(node.features, scope.children):
+            self.scope_children_id = 0
+            self.visit(feature, child_scope, types)
+     
+    @visitor.when(AttrDeclarationNode)
+    def visit(self, node, scope, types):
+        var_attr = scope.find_variable(node.id)
+        attr_type = var_attr.type
+        idx = var_attr.idx
+        
+        if isinstance(attr_type, AutoType):
+            inf_type =  self.manager.infered_type[idx]
+            if inf_type is not None:
+                if isinstance(inf_type, ErrorType):
+                    self.errors.append(AUTOTYPE_ERROR)
+                else:
+                    node.type = inf_type.name
+                    self.current_type.update_attr(node.id, inf_type)
+                scope.update_variable(node.id, inf_type)
+                attr_type = inf_type
+
+        conforms_to_types = []
+        if isinstance(attr_type, AutoType):
+            conforms_to_types.extend(self.manager.conforms_to[idx])
+        else:
+            conforms_to_types.append(attr_type)
+
+        if node.expr is not None:
+            _, computed_types = self.visit(node.expr, scope, conforms_to_types)
+            if isinstance(attr_type, AutoType):
+                self.manager.upd_conformed_by(node.idx, computed_types)
+            
+    @visitor.when(FuncDeclarationNode)
+    def visit(self, node, scope, types):
+        self.current_method = self.current_type.get_method(node.id)
+
+        method_params = []
+        for i, t in enumerate(self.current_method.param_types):
+            idx = self.current_method.param_idx[i]
+            name = self.current_method.param_names[i]
+            if isinstance(t, AutoType):
+                inf_type =  self.manager.infered_type[idx]
+                if inf_type is not None:
+                    if isinstance(inf_type, ErrorType):
+                        self.errors.append(AUTOTYPE_ERROR)
+                    else:
+                        node.params[i][1] = inf_type.name
+                        self.current_type.update_method_param(name, inf_type, i)
+                    scope.update_variable(name, inf_type)
+                    t = inf_type
+            method_params.append(t)
+
+        rtype = self.current_method.return_type
+        idx = self.current_method.ridx
+        if isinstance(rtype, AutoType):
+            inf_type =  self.manager.infered_type[idx]
+            if inf_type is not None:
+                if isinstance(inf_type, ErrorType):
+                    self.errors.append(AUTOTYPE_ERROR)
+                else:
+                    node.type = inf_type.name
+                    self.current_type.update_method_rtype(self.current_method.name, inf_type)
+                rtype = inf_type
+
+        # checking overwriting
+        try:
+            method = self.current_type.parent.get_method(node.id)    
+        
+            for i, t in enumerate(method_params):
+                if not isinstance(method.param_types[i], AutoType) and isinstance(t, AutoType):
+                    self.manager.auto_to_type(self.current_method.param_idx[i], method.param_types[i])
+                    self.manager.type_to_auto(self.current_method.param_idx[i], method.param_types[i])
+
+            if isinstance(rtype, AutoType) and not isinstance(method.return_type, AutoType):
+                self.manager.auto_to_type(idx, method.return_type)
+                self.manager.type_to_auto(idx, method.return_type)
+        except SemanticError:
+            pass
+        
+        # checking return type in computed types of the expression
+        conforms_to_types = []
+        if isinstance(rtype, AutoType):
+            conforms_to_types.extend(self.manager.conforms_to[idx])
+        else:
+            conforms_to_types.append(rtype)
+        _, computed_types = self.visit(node.body, scope, conforms_to_types)
+        if isinstance(rtype, AutoType):
+            self.manager.upd_conformed_by(self.current_method.ridx, computed_types)
+              
+    @visitor.when(AssignNode)
+    def visit(self, node, scope, types):
+        var = scope.find_variable(node.id)
+        # obtaining defined variable
+        if isinstance(var.type, AutoType):
+            inf_type =  self.manager.infered_type[var.idx]
+            if inf_type is not None:    
+                scope.update_variable(var.name, inf_type)
+                var.type = inf_type
+        
+        conforms_to_types = []
+        if isinstance(var.type, AutoType):
+            conforms_to_types.extend(self.manager.conforms_to[var.idx])
+        else:
+            conforms_to_types.append(var.type)
+        conforms_to_types.extend(types)
+
+        scope_index = self.scope_children_id
+        self.scope_children_id = 0
+        
+        typex, computed_types = self.visit(node.expr, scope.children[scope_index], conforms_to_types)
+        if isinstance(var.type, AutoType):
+            self.manager.upd_conformed_by(var.idx, computed_types)
+
+        self.scope_children_id = scope_index + 1
+        return typex, computed_types
+        
+    @visitor.when(CallNode)
+    def visit(self, node, scope, types):
+        # Check cast type
+        cast_type = None
+        if node.type is not None:
+            try:
+                cast_type = self.context.get_type(node.type)
+                if isinstance(cast_type, AutoType):
+                    cast_type = None
+                elif isinstance(cast_type, SelfType):
+                    cast_type = SelfType(self.current_type)
+            except SemanticError:
+                pass
+ 
+        conforms_to_types = [] if cast_type is None else [cast_type]
+        # Check object
+        obj_type, computed_types = self.visit(node.obj, scope, conforms_to_types)
+
+        if cast_type is None:
+            cast_type = obj_type
+
+        # if the obj that is calling the function is autotype, let it pass
+        if isinstance(cast_type, AutoType):
+            return cast_type, []
+        
+        # Check this function is defined for cast_type
+        try:
+            method = cast_type.get_method(node.id)
+            if not len(node.args) == len(method.param_types):
+                return ErrorType(), []
+            for i, arg in enumerate(node.args):
+                arg_type = method.param_types[i]
+                if isinstance(arg_type, AutoType):
+                    inf_type =  self.manager.infered_type[method.param_idx[i]]
+                    if inf_type is not None:
+                        arg_type = inf_type
+
+                conforms_to_types = []
+                if isinstance(arg_type, AutoType):
+                    conforms_to_types.extend(self.manager.conforms_to[method.param_idx[i]])
+                else:
+                    conforms_to_types.append(arg_type)
+                _, computed_types = self.visit(arg, scope, conforms_to_types)
+                if isinstance(arg_type, AutoType):
+                    self.manager.upd_conformed_by(method.param_idx[i], computed_types)
+            
+            # check return_type
+            computed_types = []
+            rtype = method.return_type
+            if isinstance(rtype, SelfType):
+                rtype = obj_type
+            
+            if isinstance(rtype, AutoType):
+                self.manager.upd_conforms_to(method.ridx, types)
+                computed_types.extend(self.manager.conformed_by[method.ridx])
+            else:
+                computed_types.append(rtype)
+
+            return rtype, computed_types
+
+        except SemanticError:
+            return ErrorType(), []
+        
+    @visitor.when(CaseNode)
+    def visit(self, node, scope, types):
+        # check expression
+        self.visit(node.expr, scope, set())
+
+        scope_index = self.scope_children_id
+        nscope = scope.children[scope_index]
+
+        # check branches
+        expr_types = []
+        for i, (branch, child_scope) in enumerate(zip(node.branch_list, nscope.children)):
+            branch_name, branch_type, expr =  branch
+            if isinstance(branch_type, AutoType):
+                inf_type =  self.manager.infered_type[node.branch_idx[i]]
+                if inf_type is not None:
+                    if isinstance(inf_type, ErrorType):
+                        self.errors.append(AUTOTYPE_ERROR)
+                    else:
+                        node.branch_list[i][1] = inf_type.name
+                    scope.update_variable(branch_name, inf_type)
+
+            self.scope_children_id = 0
+
+            _, computed_types = self.visit(expr, child_scope, types)
+            expr_types.extend(computed_types)
+
+        self.scope_children_id = scope_index + 1
+        return LCA(expr_types), expr_types
+    
+    @visitor.when(BlockNode)
+    def visit(self, node, scope, types):
+        scope_index = self.scope_children_id
+        nscope = scope.children[scope_index]
+        self.scope_children_id = 0
+
+        # Check expressions but last one
+        sz = len(node.expr_list) - 1
+        for expr in node.expr_list[:sz]:
+            self.visit(expr, nscope, [])
+
+        # Check last expression
+        typex, computed_types = self.visit(node.expr_list[-1], nscope, types)
+
+        # return the type of the last expression of the list
+        self.scope_children_id = scope_index
+        return typex, computed_types
+
+    @visitor.when(LoopNode)
+    def visit(self, node, scope, types):
+        scope_index = self.scope_children_id
+        nscope = scope.children[scope_index]
+        self.scope_children_id = 0
+
+        # checking condition: it must conform to bool
+        self.visit(node.condition, nscope, [self.bool_type])
+
+        # checking body
+        self.visit(node.body, nscope, [])
+
+        self.scope_children_id = scope_index
+        return self.obj_type, [self.obj_type]
+
+    @visitor.when(ConditionalNode)
+    def visit(self, node, scope, types):
+        # check condition conforms to bool
+        self.visit(node.condition, scope, [self.bool_type])
+        
+        branch_types = []
+
+        scope_index = self.scope_children_id
+        self.scope_children_id = 0
+        _, then_types = self.visit(node.then_body, scope.children[scope_index], types)
+        scope_index += 1
+        self.scope_children_id = 0
+        _, else_types = self.visit(node.else_body, scope.children[scope_index], types)
+
+        branch_types.extend(then_types)
+        branch_types.extend(else_types)
+
+        self.scope_children_id = scope_index + 1
+        return LCA(branch_types), branch_types
+
+    @visitor.when(LetNode)
+    def visit(self, node, scope, types):
+        scope_index = self.scope_children_id
+        nscope = scope.children[scope_index]
+        self.scope_children_id = 0
+
+        for i, item in enumerate(node.id_list):
+            var_name, _, expr = item               
+            var = scope.find_variable(var_name)
+
+            if isinstance(var.type, AutoType):
+                inf_type =  self.manager.infered_type[node.idx_list[i]]
+                if inf_type is not None:
+                    if isinstance(inf_type, ErrorType):
+                        self.errors.append(AUTOTYPE_ERROR)
+                    else:
+                        node.id_list[i] = inf_type.name
+                    scope.update_variable(var_name, inf_type)
+                    var.type = inf_type
+            
+            conforms_to_types = []
+            if isinstance(var.type, AutoType):
+                conforms_to_types.extend(self.manager.conforms_to[node.idx_list[i]])
+            else:
+                conforms_to_types.append(var.type)
+            if expr is not None:
+                _, computed_types = self.visit(expr, nscope, conforms_to_types)
+                if isinstance(var.type, AutoType):
+                    self.manager.upd_conformed_by(node.idx_list[i], computed_types)
+
+        expr_type, computed_types = self.visit(node.body, nscope, types)
+
+        self.scope_children_id = scope_index + 1
+        return expr_type, computed_types
+
+    @visitor.when(ArithmeticNode)
+    def visit(self, node, scope, types):
+        self.check_expr(node, scope)
+
+        # Check int type conforms to all the types in types
+        self.check_conformance(types, self.int_type)
+
+        return self.int_type, [self.int_type]
+
+    @visitor.when(ComparisonNode)
+    def visit(self, node, scope, types):
+        self.check_expr(node, scope)
+
+        # Check bool type conforms to all the types in types
+        self.check_conformance(types, self.bool_type)
+
+        return self.bool_type, [self.bool_type]
+
+    @visitor.when(EqualNode)
+    def visit(self, node, scope, types):
+        left, _ = self.visit(node.left, scope, [])
+        right, _ = self.visit(node.right, scope, [])
+
+        fixed_types = [self.int_type, self.bool_type, self.string_type]
+        def check_equal(typex):
+            if not isinstance(typex, AutoType) and not isinstance(typex, ErrorType):
+                for t in fixed_types:
+                    if typex.conforms_to(t):
+                        return True
+            return False
+
+        if check_equal(left):
+            self.visit(node.right, scope, [left])
+        elif check_equal(right):
+            self.visit(node.left, scope, [right])
+        
+        self.check_conformance(types, self.bool_type)
+        
+        return self.bool_type, [self.bool_type]
+
+    @visitor.when(VoidNode)
+    def visit(self, node, scope, types):
+        self.visit(node.expr, scope, [])
+        self.check_conformance(types, self.bool_type)
+
+        return self.bool_type, [self.bool_type]
+
+    @visitor.when(NotNode)
+    def visit(self, node, scope, types):
+        self.visit(node.expr, scope, [self.bool_type])
+        self.check_conformance(types, self.bool_type)
+        
+        return self.bool_type, [self.bool_type]
+
+    @visitor.when(NegNode)
+    def visit(self, node, scope, types):
+        self.visit(node.expr, scope, [self.int_type])
+        self.check_conformance(types, self.int_type)
+        
+        return self.int_type, [self.int_type]
+
+    @visitor.when(ConstantNumNode)
+    def visit(self, node, scope, types):
+        self.check_conformance(types, self.int_type)
+        return self.int_type, [self.int_type]
+
+    @visitor.when(ConstantBoolNode)
+    def visit(self, node, scope, types):
+        self.check_conformance(types, self.bool_type)
+        return self.bool_type, [self.bool_type]
+
+    @visitor.when(ConstantStringNode)
+    def visit(self, node, scope, types):
+        self.check_conformance(types, self.string_type)
+        return self.string_type, [self.string_type]
+
+    @visitor.when(VariableNode)
+    def visit(self, node, scope, types):
+        var = scope.find_variable(node.lex)
+        if isinstance(var.type, AutoType):
+            inf_type =  self.manager.infered_type[var.idx]
+            if inf_type is not None:  
+                scope.update_variable(var.name, inf_type)
+                var.type = inf_type
+        
+        conformed_by = []
+        if isinstance(var.type, AutoType):
+            self.manager.upd_conforms_to(var.idx, types)
+            conformed_by.extend(self.manager.conformed_by[var.idx])
+        else:
+            self.check_conformance(types, var.type)
+            conformed_by.append(var.type)
+
+        return var.type, conformed_by
+ 
+    @visitor.when(InstantiateNode)
+    def visit(self, node, scope, types):
+        try:
+            typex = self.context.get_type(node.lex)
+            if isinstance(typex, SelfType):
+                typex = SelfType(self.current_type)
+        except SemanticError:
+            typex = ErrorType()
+
+        self.check_conformance(types, typex)
+        
+        return typex, [typex]
+
+
+    
+    def check_expr(self, node, scope):
+        self.visit(node.left, scope, [self.int_type])
+        self.visit(node.right, scope, [self.int_type])
+
+    def check_conformance(self, types, typex):
+        for item in types:
+            if not typex.conforms_to(item):
+                self.errors.append(TYPE_CONFORMANCE %(typex.name, item.name))

--- a/cmp/type_inferencer.py
+++ b/cmp/type_inferencer.py
@@ -100,7 +100,7 @@ class TypeInferencer:
                     if isinstance(inf_type, ErrorType):
                         self.errors.append(AUTOTYPE_ERROR)
                     else:
-                        node.params[i][1] = inf_type.name
+                        node.params[i] = (node.params[i][0], inf_type.name)
                         self.current_type.update_method_param(name, inf_type, i)
                     scope.update_variable(name, inf_type)
                     t = inf_type

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from cmp.evaluation import evaluate_reverse_parse
 from cmp.formatter import FormatVisitor
 from cmp.type_collector import TypeCollector
 from cmp.type_builder import TypeBuilder
+from cmp.type_checker import TypeChecker
 
 
 def run_pipeline(G, text):
@@ -33,17 +34,26 @@ def run_pipeline(G, text):
     print('=============== BUILDING TYPES ================')
     builder = TypeBuilder(context, errors)
     builder.visit(ast)
+    manager = builder.manager
     print('Errors: [')
     for error in errors:
         print('\t', error)
     print(']')
     print('Context:')
     print(context)
+    print('=============== CHECKING TYPES ================')
+    checker = TypeChecker(context, manager, errors)
+    checker.visit(ast, None)
+    print('Errors: [')
+    for error in errors:
+        print('\t', error)
+    print(']')
+    
     return ast
 
 
 text = '''
-    class A inherits C { } ;
+    class A inherits io { } ;
     class C inherits B { } ;
     class B { } ;
     class B inherits A { } ;

--- a/test_cases/inference.txt
+++ b/test_cases/inference.txt
@@ -1,0 +1,24 @@
+text = '''
+    class A {
+        b : AUTO_TYPE ;
+        a : AUTO_TYPE ;
+        c : String ;
+        f ( ) : Int { {
+            b <- c . concat ( a ) ;
+            1 ;
+        } } ;
+    } ;
+    
+'''
+
+text = '''
+    class A {
+        b : AUTO_TYPE ;
+        a : AUTO_TYPE ;
+        c : String ;
+        f ( ) : Int { {
+            b <- c . substr ( 0 , a ) ;
+        } } ;
+    } ;
+    
+'''

--- a/test_cases/inference.txt
+++ b/test_cases/inference.txt
@@ -22,3 +22,131 @@ text = '''
     } ;
     
 '''
+
+text = '''
+    class A {
+        b : AUTO_TYPE ;
+        a : AUTO_TYPE ;
+        c : String ;
+        f ( ) : Int { {
+            b <- isvoid a ;
+            a ;
+        } } ;
+    } ;
+    
+'''
+
+se_jodio_el_self = '''
+    class A {
+        b : AUTO_TYPE ;
+        a : AUTO_TYPE ;
+        c : String ;
+        f ( ) : Int { {
+            case self of
+                x : Int => x ;
+                y : AUTO_TYPE => y ;
+            esac ;
+        } } ;
+    } ;
+    
+'''
+
+text = '''
+    class A {
+        b : AUTO_TYPE ;
+        a : AUTO_TYPE ;
+        c : String ;
+        f ( ) : Int { {
+            b <- a <- isvoid a ;
+            1 ;
+        } } ;
+    } ;
+    
+'''
+
+text = '''
+    class A {
+        b : AUTO_TYPE ;
+        a : AUTO_TYPE ;
+        c : String ;
+        f ( ) : Int { {
+            b <- foo ( a ) ;
+            1 ;
+        } } ;
+
+        foo ( k : AUTO_TYPE ) : AUTO_TYPE { k <- a } ;
+    } ;
+    
+'''
+
+text = '''
+    class A {
+        b : AUTO_TYPE ;
+        a : AUTO_TYPE ;
+        c : String ;
+        f ( ) : Int { {
+            b <- foo ( a ) ;
+            b ;
+        } } ;
+
+        foo ( k : AUTO_TYPE ) : AUTO_TYPE { k <- a } ;
+    } ;
+    
+'''
+
+text = '''
+    class B {
+        k : AUTO_TYPE ;
+    } ;
+
+    class A inherits B {
+        b : AUTO_TYPE ;
+        a : AUTO_TYPE ;
+        c : String ;
+        f ( ) : Int { {
+            b <- k + 1 ;
+            b ;
+        } } ;
+
+        foo ( k : AUTO_TYPE ) : AUTO_TYPE { k <- a } ;
+    } ;
+    
+'''
+
+text = '''
+    class B {
+        k : AUTO_TYPE ;
+    } ;
+
+    class A inherits B {
+        b : AUTO_TYPE ;
+        a : AUTO_TYPE ;
+        c : String ;
+        f ( ) : Int { {
+            b + k + a ;
+            1 ;
+        } } ;
+
+        foo ( k : AUTO_TYPE ) : AUTO_TYPE { k <- a } ;
+    } ;
+    
+'''
+
+text = '''
+    class B {
+        k : AUTO_TYPE ;
+    } ;
+
+    class A inherits B {
+        b : AUTO_TYPE ;
+        a : AUTO_TYPE ;
+        c : String ;
+        f ( ) : Int { {
+            b + a ;
+            k <- b . copy ( ) ;
+        } } ;
+
+        foo ( k : AUTO_TYPE ) : AUTO_TYPE { k <- a } ;
+    } ;
+    
+'''


### PR DESCRIPTION
Fixes #9 
- Adding auto_type as another Type of the context
- Implementing Inferencer Manager to deal with the group of types an autotype conforms to and the group of types which conforms to this autotype
- Implementing Type Inferencer visitor